### PR TITLE
Add support for mocked events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -169,6 +169,7 @@ function compareHotkey(object, event) {
       actual = event[key]
     }
 
+    if (actual == null && expected == false) continue
     if (actual != expected) return false
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -102,6 +102,12 @@ describe('is-hotkey', () => {
       const value = curried(event)
       assert.equal(value, true)
     })
+
+    it('matches mocked event', () => {
+      const event = { which: 13 }
+      const value = isHotkey('enter', event)
+      assert.equal(value, true)
+    })
   })
 
   describe('byKey', () => {
@@ -181,6 +187,12 @@ describe('is-hotkey', () => {
       const event = e('s', 'meta')
       const curried = isHotkey('cmd+s', { byKey: true })
       const value = curried(event)
+      assert.equal(value, true)
+    })
+
+    it('matches mocked event', () => {
+      const event = { key: 'Enter' }
+      const value = isHotkey('enter', { byKey: true }, event)
       assert.equal(value, true)
     })
   })


### PR DESCRIPTION
As mentioned in the issue #6, right now:
```js
isKeyHotkey('enter', { key: 'Enter' })
```
returns `false`. This PR fixes this use case to return `true`.