### PR TITLE
Throw an error if provided with non-modifier keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,6 +136,10 @@ function parseHotkey(hotkey, options) {
     const name = toKeyName(value)
     const modifier = MODIFIERS[name]
 
+    if (value.length > 1 && !modifier && !ALIASES[value] && !CODES[name]) {
+      throw new TypeError(`Unknown modifier: "${value}"`)
+    }
+
     if (length === 1 || !modifier) {
       if (byKey) {
         ret.key = name

--- a/test/index.js
+++ b/test/index.js
@@ -128,6 +128,15 @@ describe('is-hotkey', () => {
       assert.equal(a, true)
       assert.equal(s, true)
     })
+
+    it('fails on non-modifier keys', () => {
+      assert.throws(
+        () => {
+          isHotkey('ctrlalt+k')
+        },
+        (err) => err instanceof TypeError && err.message === 'Unknown modifier: "ctrlalt"'
+      )
+    })
   })
 
   describe('byKey', () => {
@@ -228,6 +237,15 @@ describe('is-hotkey', () => {
       const s = check(e('s', 'meta'))
       assert.equal(a, true)
       assert.equal(s, true)
+    })
+
+    it('fails on non-modifier keys', () => {
+      assert.throws(
+        () => {
+          isHotkey('ctrlalt+k')
+        },
+        (err) => err instanceof TypeError && err.message === 'Unknown modifier: "ctrlalt"'
+      )
     })
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -240,9 +240,10 @@ describe('is-hotkey', () => {
     })
 
     it('fails on non-modifier keys', () => {
+      const event = e('k', 'ctrl', 'alt')
       assert.throws(
         () => {
-          isHotkey('ctrlalt+k')
+          isHotkey('ctrlalt+k', { byKey: true }, event)
         },
         (err) => err instanceof TypeError && err.message === 'Unknown modifier: "ctrlalt"'
       )


### PR DESCRIPTION
Fixes #4.

Idea: check if the value is not a single-length character, not in `MODIFIERS`, not in`ALIASES` and not in `CODES`. 
If all these conditions are true, throw a `TypeError`.

This is a potentially breaking change, but the code which would trigger this error is already (silently) broken. 
