### PR TITLE
Add umd build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,14 +7,16 @@
   "main": "./lib/index.js",
   "scripts": {
     "build": "babel ./src --out-dir ./lib",
+    "build:umd": "babel --plugins transform-es2015-modules-umd ./src -o ./lib/is-hotkey.umd.js",
     "clean": "rm -rf ./lib ./node_modules",
-    "prepublish": "yarn run build",
+    "prepublish": "yarn run build && yarn run build:umd",
     "release": "np",
     "test": "yarn run build && mocha",
     "watch": "babel ./lib --out-dir ./lib --watch"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",
+    "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
     "babel-preset-env": "^1.6.1",
     "mocha": "^3.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -398,7 +398,7 @@ babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-modules-umd@^6.23.0:
+babel-plugin-transform-es2015-modules-umd@^6.23.0, babel-plugin-transform-es2015-modules-umd@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz#ac997e6285cd18ed6176adb607d602344ad38468"
   dependencies:


### PR DESCRIPTION
Closes #8.

[`babel-plugin-transform-es2015-modules-umd`](https://babeljs.io/docs/en/babel-plugin-transform-es2015-modules-umd) is an easy way to get the umd build from the existing sources, which are also using babel to create a release build.
I have added a separate `build:umd` script to create the umd build and output it at `lib/is-hotkey.umd.js`. I have added it only to the `prepublish` script, so it's not adding to the test and/or build time.
I believe there's no need for the minified version, which was mentioned in the #8; the script is tiny in size as it is. For production builds, the consumer can add minification to their pipeline. 
@ianstormtaylor I hope this still works with your `np` config.
With this change, the script should be available at unpkg.com/is-hotkey/lib/is-hotkey.umd.js