### PR TITLE
Add getModName function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -201,6 +201,10 @@ function toKeyName(name) {
   return name
 }
 
+function getModName() {
+  return IS_MAC ? 'Cmd' : 'Ctrl'
+}
+
 /**
  * Export.
  */
@@ -215,4 +219,5 @@ export {
   compareHotkey,
   toKeyCode,
   toKeyName,
+  getModName
 }


### PR DESCRIPTION
Sometimes the name of mod needs to be displayed, such as on the tip of the button.