### PR TITLE
Fix for `?` key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "is-hotkey",
+  "name": "@aha-app/is-hotkey",
   "description": "Check whether a browser event matches a hotkey.",
-  "version": "0.1.4",
+  "version": "0.1.4a",
   "license": "MIT",
-  "repository": "git://github.com/ianstormtaylor/is-hotkey.git",
+  "repository": "git://github.com/bpaul/is-hotkey.git",
   "main": "./lib/index.js",
   "scripts": {
     "build": "babel ./src --out-dir ./lib",

--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,7 @@ function parseHotkey(hotkey, options) {
   }
 
   for (let value of values) {
-    const optional = value.endsWith('?')
+    const optional = value.endsWith('?') && value.length > 1;
 
     if (optional) {
       value = value.slice(0, -1)

--- a/src/index.js
+++ b/src/index.js
@@ -215,4 +215,5 @@ export {
   compareHotkey,
   toKeyCode,
   toKeyName,
-}
+  IS_MAC,
+};

--- a/test/index.js
+++ b/test/index.js
@@ -107,6 +107,12 @@ describe('is-hotkey', () => {
       const value = isHotkey('cmd+alt?+s', event)
       assert.equal(value, true)
     })
+    
+    it("matches question mark key", () => {
+      const event = e("?");
+      const value = isHotkey("?", { byKey: true }, event);
+      assert.equal(value, true);
+    });
 
     it('can be curried', () => {
       const event = e(83, 'meta')


### PR DESCRIPTION
The optional keys feature broke the raw `?` key, `parseHotkey('?')` returns `''`. 

This is because the optional key feature was using `endsWith` to detect optional keys. Of course `'?'.endsWith('?')` is true! 

Added a test and fixed the issue, thanks!

I also added IS_MAC to the exports as this is useful to have when displaying hotkeys.