### PR TITLE
Fix for '?' key (clean branch)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,7 @@ function parseHotkey(hotkey, options) {
   }
 
   for (let value of values) {
-    const optional = value.endsWith('?')
+    const optional = value.endsWith('?') && value.length > 1;
 
     if (optional) {
       value = value.slice(0, -1)

--- a/test/index.js
+++ b/test/index.js
@@ -108,6 +108,12 @@ describe('is-hotkey', () => {
       assert.equal(value, true)
     })
 
+    it("matches question mark key", () => {
+      const event = e("?");
+      const value = isHotkey("?", { byKey: true }, event);
+      assert.equal(value, true);
+    });
+
     it('can be curried', () => {
       const event = e(83, 'meta')
       const curried = isHotkey('cmd+s')


### PR DESCRIPTION
The optional keys feature broke the raw `?` key, `parseHotkey('?')` returns `''`.

This is because the optional key feature was using endsWith to detect optional keys. Of course `'?'.endsWith('?')` is true!

Added a test and fixed the issue, thanks!
