### PR TITLE
Check if key is defined before lowercasing it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,7 @@ function compareHotkey(object, event) {
       continue
     }
 
-    if (key === 'key') {
+    if (key === 'key' && event.key) {
       actual = event.key.toLowerCase()
     } else if (key === 'which') {
       actual = expected === 91 && event.which === 93 ? 91 : event.which

--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,7 @@ function compareHotkey(object, event) {
       continue
     }
 
-    if (key === 'key' && event.key) {
+    if (key === 'key' && event.key != null) {
       actual = event.key.toLowerCase()
     } else if (key === 'which') {
       actual = expected === 91 && event.which === 93 ? 91 : event.which


### PR DESCRIPTION
Key can be undefined if the keypress is unrecognized.
This behaviour can be reproduced on chrome using a password manager to fill out a form (dashlane for example).

Error: 
![Screenshot 2019-09-16 17 21 30](https://user-images.githubusercontent.com/22725/65003507-a4f56c00-d8ad-11e9-8db3-5d53dc8eb3cd.png)

KeyboardEvent spec https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key

