### PR TITLE
Added ability to be used using a switch statment (#46)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,6 +9,7 @@ A simple way to check whether a browser event matches a hotkey.
 
 - Uses a simple, natural syntax for expressing hotkeys—`mod+s`, `cmd+alt+space`, etc.
 - Accepts `mod` for the classic "`cmd` on Mac, `ctrl` on Windows" use case.
+- Can be used using `switch`.
 - Can use either `event.which` (default) or `event.key` to work regardless of keyboard layout.
 - Can be curried to reduce parsing and increase performance when needed.
 - Is very lightweight, weighing in at `< 1kb` minified and gzipped.
@@ -40,6 +41,21 @@ function onKeyDown(e) {
   if (isSaveHotkey(e)) {
     ...
   }
+}
+```
+
+It is also possible to use it using a switch statment by converting the event to a hotkey:
+
+```js
+switch (getHotkeyName(event)) {
+  case "mod+s":
+    event.preventDefault();
+    console.log("Save");
+    break;
+  case "mod+c":
+    event.preventDefault();
+    console.log("Copy");
+    break;
 }
 ```
 
@@ -126,6 +142,13 @@ isKeyHotkey('mod+s', event)
 By default the hotkey string is checked using `event.which`. But you can also pass in `byKey: true` to compare using the [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) API, which stays the same regardless of keyboard layout.
 
 Or to reduce the noise if you are defining lots of hotkeys, you can use the `isCodeHotkey` and `isKeyHotkey` helpers that are exported.
+
+```js
+// Event: ctrl + s
+const hotkeyName = getHotkeyName(event); // "mod+s"
+```
+
+You can get the hotkey name of an event using the `getHotkeyName` function, in case you would want to use a switch statement for example.
 
 ```js
 import { toKeyName, toKeyCode } from 'is-hotkey'

--- a/src/index.js
+++ b/src/index.js
@@ -245,4 +245,6 @@ export {
   compareHotkey,
   toKeyCode,
   toKeyName,
+  getHotkeyName,
+  toHotkeyName,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -108,6 +108,22 @@ function isKeyHotkey(hotkey, event) {
   return isHotkey(hotkey, { byKey: true }, event)
 }
 
+/*
+* Get hotkey.
+*/
+
+function getHotkeyName(event) {
+  const eventHotkey = {
+    altKey: event.altKey,
+    ctrlKey: event.ctrlKey,
+    metaKey: event.metaKey,
+    shiftKey: event.shiftKey,
+    key: event.key
+  };
+
+  return toHotkeyName(eventHotkey);
+}
+
 /**
  * Parse.
  */
@@ -204,6 +220,16 @@ function toKeyName(name) {
   name = ALIASES[name] || name
   return name
 }
+
+function toHotkeyName(hotkey) {
+  const name = [];
+  if (hotkey.ctrlKey || hotkey.metaKey) name.push("mod");
+  if (hotkey.shiftKey) name.push("shift");
+  if (hotkey.altKey) name.push("alt");
+  name.push();
+  return name.join("+");
+}
+
 
 /**
  * Export.

--- a/test/index.js
+++ b/test/index.js
@@ -257,3 +257,7 @@ describe('is-hotkey', () => {
   })
 
 })
+
+describe('getHotkeyName', () => {
+  
+})


### PR DESCRIPTION
# Description

I added a `toHotkeyName` and a `getHotKeyName` function in order to convert an event to a hotkey name that can then be used inside a switch statement.

I also took the time to add the necessary documentation though it might not be fully complete as I didn't describe the `toHotKeyName` function.

Fixes #46

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# How To Verify?

If you would like, you could test this feature in [this sandbox](https://codesandbox.io/s/serverless-forest-gp4gww).